### PR TITLE
Various STF trace fixes

### DIFF
--- a/include/dromajo_stf.h
+++ b/include/dromajo_stf.h
@@ -11,7 +11,7 @@
 
 extern stf::STFWriter stf_writer;
 extern void stf_record_state(RISCVMachine * m, int hartid, uint64_t last_pc);
-extern void stf_trace_element(RISCVMachine * m, int hartid,int priv, uint64_t last_pc, uint32_t insn);
+extern void stf_trace_element(RISCVMachine * m, int hartid,int priv, uint64_t last_pc, uint32_t insn, bool insn_executed);
 extern bool stf_trace_trigger(RISCVMachine * m, int hartid, uint32_t insn);
 extern void stf_trace_open(RISCVMachine * m, int hartid, uint64_t PC);
 extern void stf_trace_close(RISCVMachine * m, uint64_t PC);

--- a/include/machine.h
+++ b/include/machine.h
@@ -274,7 +274,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv);
 void          virt_machine_end(RISCVMachine *s);
 void          virt_machine_serialize(RISCVMachine *m, const char *dump_name);
 void          virt_machine_deserialize(RISCVMachine *m, const char *dump_name);
-BOOL          virt_machine_run(RISCVMachine *m, int hartid, int n_cycles);
+BOOL          virt_machine_run(RISCVMachine *m, int hartid, int n_cycles, int *insn_executed);
 uint64_t      virt_machine_get_pc(RISCVMachine *m, int hartid);
 uint64_t      virt_machine_get_reg(RISCVMachine *m, int hartid, int rn);
 uint64_t      virt_machine_get_fpreg(RISCVMachine *m, int hartid, int rn);

--- a/include/riscv_cpu.h
+++ b/include/riscv_cpu.h
@@ -357,6 +357,7 @@ typedef struct RISCVCPUState {
     std::vector<stf_mem_access> stf_mem_reads;
     std::vector<stf_mem_access> stf_mem_writes;
     uint8_t stf_prev_priv_mode;
+    uint16_t stf_prev_asid;
 
 } RISCVCPUState;
 

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -152,7 +152,7 @@ static int iterate_core(RISCVMachine *m, int hartid, int n_cycles) {
      */
     uint64_t last_pc  = virt_machine_get_pc(m, hartid);
     int      priv     = riscv_get_priv_level(cpu);
-    uint32_t insn_raw = -1;
+    uint32_t insn_raw = 0;
     bool     do_trace = false;
     int      insn_executed;
 

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -154,6 +154,7 @@ static int iterate_core(RISCVMachine *m, int hartid, int n_cycles) {
     int      priv     = riscv_get_priv_level(cpu);
     uint32_t insn_raw = -1;
     bool     do_trace = false;
+    int      insn_executed;
 
     (void)riscv_read_insn(cpu, &insn_raw, last_pc);
     if (m->common.trace < (unsigned)n_cycles) {
@@ -162,12 +163,12 @@ static int iterate_core(RISCVMachine *m, int hartid, int n_cycles) {
     } else
         m->common.trace -= n_cycles;
 
-    int keep_going = virt_machine_run(m, hartid, n_cycles);
+    int keep_going = virt_machine_run(m, hartid, n_cycles, &insn_executed);
 
     if(m->common.stf_trace) {
         // Returns true if current instruction should be traced
         if(stf_trace_trigger(m, hartid, insn_raw)) {
-            stf_trace_element(m, hartid, priv, last_pc, insn_raw);
+            stf_trace_element(m, hartid, priv, last_pc, insn_raw, insn_executed > 0);
         }
     }
 

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -491,10 +491,10 @@ static EthernetDevice *slirp_open(void) {
 
 #endif /* CONFIG_SLIRP */
 
-BOOL virt_machine_run(RISCVMachine *s, int hartid, int n_cycles) {
+BOOL virt_machine_run(RISCVMachine *s, int hartid, int n_cycles, int *insn_executed) {
     (void)virt_machine_get_sleep_duration(s, hartid, MAX_SLEEP_TIME);
 
-    riscv_cpu_interp64(s->cpu_state[hartid], n_cycles);
+    *insn_executed = riscv_cpu_interp64(s->cpu_state[hartid], n_cycles);
     RISCVCPUState *cpu = s->cpu_state[hartid];
     if (s->htif_tohost_addr) {
         uint32_t tohost;

--- a/src/riscv_cpu.cpp
+++ b/src/riscv_cpu.cpp
@@ -307,7 +307,6 @@ static inline bool check_triggers(RISCVCPUState *s, target_ulong t_mctl, target_
             *fail = true;                                                                            \
             return;                                                                                  \
         }                                                                                            \
-        track_write(s, paddr, paddr, val, size);                                                     \
         *(uint_type *)(pr->phys_mem + (uintptr_t)(paddr - pr->addr)) = val;                          \
         *fail                                                        = false;                        \
     }                                                                                                \
@@ -319,7 +318,6 @@ static inline bool check_triggers(RISCVCPUState *s, target_ulong t_mctl, target_
             return 0;                                                                                \
         }                                                                                            \
         uint_type pval = *(uint_type *)(pr->phys_mem + (uintptr_t)(paddr - pr->addr));               \
-        pval           = track_dread(s, paddr, paddr, pval, size);                                   \
         *fail          = false;                                                                      \
         return pval;                                                                                 \
     }


### PR DESCRIPTION
1. Stop tracing page table walk memory accesses for normal load store instructions
2. PC was incorrect as trace starts
3. Properly use the STF event PC record for tracing changes in PC for exceptions
4. Report privilege mode at the start of trace
5. Track ASID as a ProcessID record
6. Trace through changes in ASID - not doing this could result in corrupted traces
7. Default to insn=0 incase we hit a page fault